### PR TITLE
Safe types for guessing bot

### DIFF
--- a/src/Chat/Bot/Answer/Guess.hs
+++ b/src/Chat/Bot/Answer/Guess.hs
@@ -9,7 +9,7 @@ import           System.Random
 
 
 guessMeAnswer :: Secret -> Guess -> String
-guessMeAnswer s g = case compare s g of
+guessMeAnswer (Secret s) (Guess g) = case compare s g of
   LT -> "lower"
   GT -> "higher"
   EQ -> "hit!"
@@ -30,7 +30,7 @@ guessBot = do
       let g' = read g
       -- Reset the guess when it's correct
       when (n == g') $ nextGuess number
-      return . Just $ guessMe n g'
+      return . Just $ guessMe (Secret n) (Guess g')
 
 nextGuess :: MVar Int -> IO ()
 nextGuess number =

--- a/src/Chat/Bot/Guess.hs
+++ b/src/Chat/Bot/Guess.hs
@@ -7,8 +7,8 @@ import           Chat.Data
 --
 -- This requires implementing comparing two numbers and display a message depending on the result
 guessMe :: Secret -> Guess -> String
-guessMe s g =
+guessMe (Secret s) (Guess g) =
   error "guessMe not implemented"
 
-type Guess = Int
-type Secret = Int
+newtype Guess = Guess Int
+newtype Secret = Secret Int


### PR DESCRIPTION
If we are going to bother with giving guessMe a type beyond `Int -> Int -> String` we might as well do it properly.

We already introduced `data' in the Introduction.md

(There's an argument to be made to use `data' here instead of
newtype, to avoid explaining newtype.)

Alternatively, we can stick to `Int -> Int -> String`.
